### PR TITLE
Bookmark

### DIFF
--- a/src/components/News.js
+++ b/src/components/News.js
@@ -72,7 +72,7 @@ const News = ({ news, onBookmarkToggle, bookmarked }) => {
                         &nbsp;
                         {news.publishedAt
                             ? news.publishedAt
-                                  .substring(0, news.publishedAt.length - 1)
+                                  .slice(0, -1)
                                   .split("T")
                                   .join(" ")
                             : null}


### PR DESCRIPTION
Re-arranged the `publishedAt` time format, apparently, `T` & `Z` in `publishedAt` stayed unnoticed till now.